### PR TITLE
fix(autonomy): dispatch MQTT-triggered items concurrently (#78)

### DIFF
--- a/services/agent/selene_agent/autonomy/mqtt_listener.py
+++ b/services/agent/selene_agent/autonomy/mqtt_listener.py
@@ -46,6 +46,10 @@ class MqttListener:
         self._subscriptions: Set[str] = set()
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._backoff = 1.0
+        # Detached per-item trigger tasks. Held so the event loop keeps a strong
+        # reference (asyncio only weakly references tasks) and so stop() can
+        # cancel any still in flight.
+        self._inflight: Set[asyncio.Task] = set()
 
     # --- lifecycle ----------------------------------------------------
 
@@ -82,6 +86,9 @@ class MqttListener:
         for task in (self._consumer_task, self._refresher_task, self._reconnect_task):
             if task:
                 task.cancel()
+        for task in list(self._inflight):
+            task.cancel()
+        self._inflight.clear()
         self._consumer_task = None
         self._refresher_task = None
         self._reconnect_task = None
@@ -192,10 +199,33 @@ class MqttListener:
                 continue
             if not match(spec, event):
                 continue
-            try:
-                await self.engine.trigger_event(item["id"], source="mqtt", event=event)
-            except Exception as e:
-                logger.error(f"[mqtt] trigger_event failed for {item['id']}: {e}")
+            # Fire as a detached, tracked task so the consumer keeps draining the
+            # queue instead of blocking on the whole watch_llm gather + LLM turn
+            # (60s+). Latency-sensitive events (e.g. front-door face triage) must
+            # not sit behind a slow unrelated turn. Backpressure is the engine's
+            # job: trigger_event skips an item already in _running_items and
+            # enforces the per-item event rate limit, so a burst for one item is
+            # dropped rather than serialized. Mirrors the cron dispatch path,
+            # which already uses create_task for this reason.
+            task = asyncio.create_task(
+                self._fire_matched(item["id"], event),
+                name=f"autonomy-mqtt-fire-{item['id']}",
+            )
+            self._inflight.add(task)
+            task.add_done_callback(self._inflight.discard)
+
+    async def _fire_matched(self, item_id: str, event: Dict[str, Any]) -> None:
+        """Run one matched item's trigger to completion as a detached task.
+
+        Exceptions are logged here so they don't vanish into an un-awaited task
+        (asyncio would otherwise only surface them at GC as
+        'Task exception was never retrieved'). CancelledError is BaseException,
+        not Exception, so a stop()-driven cancel propagates cleanly.
+        """
+        try:
+            await self.engine.trigger_event(item_id, source="mqtt", event=event)
+        except Exception as e:
+            logger.error(f"[mqtt] trigger_event failed for {item_id}: {e}")
 
     async def _refresh_loop(self) -> None:
         """Diff-subscribe/unsubscribe when the engine's refresh event fires."""


### PR DESCRIPTION
Resolves #78.

## Problem
The MQTT consumer (`_consume`) awaited `_dispatch_message` inline, which awaited `engine.trigger_event` to completion per matching item — including the full watch_llm gather + LLM turn (60s+). One slow event (e.g. a ~45s backyard wildlife triage) blocked the consumer from starting the next event; the latency-sensitive front-door who-is-at-the-door triage sat behind it, and camera bursts backed the 1024-slot queue up until it dropped messages.

## Fix
Matched items now fire as detached, tracked `asyncio` tasks so intake keeps draining. Backpressure stays the engine's job — `trigger_event` already skips items still in `_running_items` and enforces the per-item event rate limit, so a burst for one item is dropped rather than serialized. Mirrors the cron dispatch path, which already uses `create_task`. Tasks are strongly referenced in a set and cleared via done-callback; `stop()` cancels any in flight; detached-task exceptions are logged instead of lost.

## Verification
Runtime harness against the real listener: with a 500ms backyard turn in flight, a following front-door event's trigger starts immediately (concurrent, not serialized); detached-task exceptions are logged; `stop()` cancels in-flight tasks. 63 autonomy tests pass (`test_sensor_events`, `test_trigger_match`, `test_event_rate_limit`, `test_watch_handler`, `test_watch_llm_handler`, `test_quiet_hours`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)