### PR TITLE
fix(agent): pass log_config=None to uvicorn to avoid Loki logging deadlock at startup

### DIFF
--- a/services/agent/selene_agent/selene_agent.py
+++ b/services/agent/selene_agent/selene_agent.py
@@ -60,7 +60,7 @@ logger = custom_logger.get_logger('loki')
 # out the lines we actually care about. Apply after get_logger() so the
 # dictConfig in the custom logger module doesn't override these.
 import logging as _logging
-for _noisy in ("httpx", "httpcore", "openai"):
+for _noisy in ("httpx", "httpcore", "openai", "urllib3"):
     _logging.getLogger(_noisy).setLevel(_logging.WARNING)
 
 
@@ -605,7 +605,14 @@ def main():
     if args.api_key:
         config.LLM_API_KEY = args.api_key
 
-    uvicorn.run(app, host="0.0.0.0", port=6002, log_level="info")
+    # log_config=None: the app already owns logging via custom_logger's
+    # _configure_once() (console + async Loki QueueListener). Letting uvicorn run
+    # its own dictConfig at startup calls logging.shutdown()/_clearExistingHandlers
+    # while the Loki background thread is mid-emit() -> requests.post -> urllib3 ->
+    # logging.debug. That crosses the global logging lock and the Loki handler lock
+    # in opposite orders, deadlocking startup so uvicorn never binds port 6002
+    # (agent stays unhealthy, nginx never comes up). Keep uvicorn out of logging.
+    uvicorn.run(app, host="0.0.0.0", port=6002, log_level="info", log_config=None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The agent container hung at startup — uvicorn never bound `:6002`, so the healthcheck failed indefinitely (274 consecutive failures) and `nginx` stayed in `Created` (it waits for agent to be healthy).

## Root cause

An **ABBA deadlock** between Python's global logging lock and the Loki handler lock, exposed once Loki shipping moved onto a persistent `QueueListener` background thread (`d409614`):

- **Loki thread:** `LokiHandler.emit → requests.post → urllib3 → logging.debug` takes the global logging lock **while holding the handler lock**.
- **Main thread:** `uvicorn.run → configure_logging → dictConfig → _clearExistingHandlers → logging.shutdown` takes the handler lock **while holding the global logging lock**.

A remote `LOKI_URL` makes the Loki thread dwell inside `requests.post` long enough that the collision happens on essentially every boot. Captured via a `faulthandler` watchdog reproduction.

## Fix

The app already fully owns logging via `custom_logger._configure_once()` (console + async Loki `QueueListener`), so uvicorn has no business re-running `dictConfig`. Passing `log_config=None` removes uvicorn's half of the deadlock (and stops it clobbering the app's handlers — something the code's own comments already worried about). Also quiets `urllib3` as defense-in-depth against re-entrant logging on the Loki HTTP path.

## Verification

- Reproduced the original deadlock with a `faulthandler` watchdog (both deadlocked stacks captured).
- After the fix: `--force-recreate` of the agent container → `/health` responds in ~5s, healthcheck flips `healthy`, nginx starts, and `http://localhost/health` (nginx → agent:6002) returns **HTTP 200**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
