### PR TITLE
fix(agent): keep an abandoned turn from poisoning the pooled session

### DIFF
--- a/services/agent/selene_agent/api/chat.py
+++ b/services/agent/selene_agent/api/chat.py
@@ -34,6 +34,7 @@ Device-name attribution:
 """
 
 import asyncio
+from contextlib import aclosing
 from typing import Any, List, Optional
 
 from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect, Request, Response, Header
@@ -158,23 +159,28 @@ async def chat(
 
     lock = pool.lock_for(session_id)
     async with lock:
-        async for event in orchestrator.run(request.message):
-            # REASONING events are dashboard-only chain-of-thought surfaced on
-            # /ws/chat. Drop them from the REST response so satellites and
-            # other REST callers never see the CoT text.
-            if event.type == EventType.REASONING:
-                continue
-            events.append({"type": event.type.value, **event.data})
-            if event.type == EventType.METRIC:
-                await metrics_db.record_turn(
-                    orchestrator.session_id,
-                    event.data,
-                    device_name=orchestrator.device_name,
-                )
-            elif event.type == EventType.DONE:
-                final_content = event.data.get("content", "")
-            elif event.type == EventType.ERROR:
-                final_content = event.data.get("error", "ERROR: Unknown error")
+        # aclosing(): uvicorn cancels this handler task when the client goes
+        # away. Closing the generator deterministically lets run()'s finally
+        # repair any tool_calls the abandoned turn left unanswered, instead of
+        # leaving the pooled session wedged until GC finalizes the generator.
+        async with aclosing(orchestrator.run(request.message)) as stream:
+            async for event in stream:
+                # REASONING events are dashboard-only chain-of-thought surfaced
+                # on /ws/chat. Drop them from the REST response so satellites
+                # and other REST callers never see the CoT text.
+                if event.type == EventType.REASONING:
+                    continue
+                events.append({"type": event.type.value, **event.data})
+                if event.type == EventType.METRIC:
+                    await metrics_db.record_turn(
+                        orchestrator.session_id,
+                        event.data,
+                        device_name=orchestrator.device_name,
+                    )
+                elif event.type == EventType.DONE:
+                    final_content = event.data.get("content", "")
+                elif event.type == EventType.ERROR:
+                    final_content = event.data.get("error", "ERROR: Unknown error")
 
     return ChatResponse(response=final_content, events=events, session_id=session_id)
 
@@ -303,17 +309,38 @@ async def websocket_chat(websocket: WebSocket):
 
                 lock = pool.lock_for(sid)
                 async with lock:
-                    async for event in orch.run(user_message):
-                        await websocket.send_json({
-                            "type": event.type.value,
-                            **event.data,
-                        })
-                        if event.type == EventType.METRIC:
-                            await metrics_db.record_turn(
-                                orch.session_id,
-                                event.data,
-                                device_name=orch.device_name,
-                            )
+                    # If the client vanishes mid-turn, sending raises. Do NOT
+                    # let that abandon the generator at its current yield: the
+                    # assistant message carrying tool_calls is already in
+                    # orch.messages and the matching tool results are appended
+                    # after the yields, so a dropped turn would leave the
+                    # pooled session (and its conversation_db flush) in a
+                    # sequence the provider rejects on every later turn.
+                    # Instead stop sending and drain the turn to completion.
+                    send_error: Optional[Exception] = None
+                    async with aclosing(orch.run(user_message)) as stream:
+                        async for event in stream:
+                            if send_error is None:
+                                try:
+                                    await websocket.send_json({
+                                        "type": event.type.value,
+                                        **event.data,
+                                    })
+                                except Exception as e:
+                                    send_error = e
+                                    logger.warning(
+                                        f"WS send failed mid-turn (session={sid}): {e}. "
+                                        "Draining the turn so session state settles."
+                                    )
+                            if event.type == EventType.METRIC:
+                                await metrics_db.record_turn(
+                                    orch.session_id,
+                                    event.data,
+                                    device_name=orch.device_name,
+                                )
+                    if send_error is not None:
+                        # Turn finished cleanly; the socket is the casualty.
+                        raise WebSocketDisconnect(code=1006)
 
     except WebSocketDisconnect:
         logger.info(f"WebSocket client disconnected (session={session_id})")

--- a/services/agent/selene_agent/orchestrator.py
+++ b/services/agent/selene_agent/orchestrator.py
@@ -702,6 +702,15 @@ class AgentOrchestrator:
         retrieval_block = await self._build_retrieval_block(user_message)
 
         try:
+            # Heal history poisoned before this fix (or by a cold resume from a
+            # conversation_db row flushed mid-turn) so the very first turn on a
+            # recovered session isn't rejected by the provider.
+            inherited = self._repair_dangling_tool_calls()
+            if inherited:
+                logger.warning(
+                    f"Session {self.session_id} carried {inherited} unanswered "
+                    "tool_call(s) into this turn; synthesized placeholder results"
+                )
             self.messages.append({"role": "user", "content": wrapped_message})
             logger.info(f"Query: {user_message}")
 
@@ -991,6 +1000,75 @@ class AgentOrchestrator:
         except Exception as e:
             logger.error(f"Error in query: {e}\n{traceback.format_exc()}")
             yield AgentEvent(type=EventType.ERROR, data={"error": f"ERROR: {str(e)}"})
+        finally:
+            # Runs on the normal path, on error, and on GeneratorExit /
+            # CancelledError (client disconnect mid-turn) — see
+            # _repair_dangling_tool_calls. Must stay await-free: a `finally`
+            # in an async generator cannot suspend while it's being closed.
+            repaired = self._repair_dangling_tool_calls()
+            if repaired:
+                logger.warning(
+                    f"Turn abandoned mid tool-loop (session_id={self.session_id}); "
+                    f"synthesized {repaired} placeholder tool result(s) to keep "
+                    "the message history valid"
+                )
+
+    def _repair_dangling_tool_calls(self) -> int:
+        """Answer any assistant tool_calls in self.messages left without a result.
+
+        run() appends the assistant message carrying `tool_calls` *before* it
+        yields TOOL_CALL/TOOL_RESULT and appends the matching `role=tool`
+        replies. A turn abandoned in that window (WS client disconnect, REST
+        request cancellation) leaves an assistant entry whose tool_calls have
+        no responses — an invalid sequence the provider rejects, wedging every
+        later turn on the session and poisoning the conversation_db flush.
+
+        Fill each gap with a synthetic tool result, inserted immediately after
+        that assistant message's existing tool replies. Returns how many were
+        synthesized (0 = history was already well-formed, nothing mutated).
+        """
+        repaired: List[Dict[str, Any]] = []
+        pending: List[str] = []
+        synthesized = 0
+
+        def _flush() -> int:
+            n = len(pending)
+            for tcid in pending:
+                repaired.append({
+                    "role": "tool",
+                    "tool_call_id": tcid,
+                    "content": json.dumps({
+                        "error": "tool_call_abandoned",
+                        "detail": (
+                            "The turn ended before this tool call completed "
+                            "(client disconnected). No result is available."
+                        ),
+                    }),
+                })
+            pending.clear()
+            return n
+
+        for m in self.messages:
+            role = m.get("role")
+            if role == "tool":
+                tcid = m.get("tool_call_id")
+                if tcid in pending:
+                    pending.remove(tcid)
+                repaired.append(m)
+                continue
+            # Any non-tool message ends this assistant's run of tool replies.
+            synthesized += _flush()
+            if role == "assistant":
+                for tc in (m.get("tool_calls") or []):
+                    tcid = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+                    if tcid:
+                        pending.append(tcid)
+            repaired.append(m)
+        synthesized += _flush()
+
+        if synthesized:
+            self.messages[:] = repaired
+        return synthesized
 
     async def _execute_tool_call(self, tool_call) -> str:
         """Execute a single tool call via MCP (or the companion-upload path)."""

--- a/services/agent/tests/test_abandoned_turn_repair.py
+++ b/services/agent/tests/test_abandoned_turn_repair.py
@@ -1,0 +1,246 @@
+"""Regression tests for issue #39 — an abandoned turn must not poison the session.
+
+run() appends the assistant message carrying ``tool_calls`` *before* it yields
+TOOL_CALL/TOOL_RESULT and appends the matching ``role=tool`` replies. A turn
+dropped in that window (WS client disconnect, REST request cancellation) used
+to leave the pooled session with unanswered tool_calls — an invalid sequence
+the provider rejects, so every later turn on that session_id failed.
+
+Covers:
+- ``_repair_dangling_tool_calls`` unit: well-formed history untouched; trailing
+  gap filled; partial answers topped up; mid-history gap filled in place.
+- run()'s ``finally``: closing the generator mid tool-loop (the disconnect
+  shape) leaves ``orch.messages`` well-formed.
+- Normal completion synthesizes nothing.
+- A session cold-resumed with a pre-existing gap is healed before its first
+  LLM call, not after.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, List, Optional
+from unittest.mock import MagicMock
+
+from selene_agent.orchestrator import AgentOrchestrator, EventType
+
+
+# ---------- Helpers ----------
+
+
+def _mk_tool_call(tc_id: str, name: str = "ha_control_light", args: str = "{}"):
+    """Provider-style tool_call object (attribute access, as the SDK returns)."""
+    tc = MagicMock()
+    tc.id = tc_id
+    tc.function = MagicMock()
+    tc.function.name = name
+    tc.function.arguments = args
+    return tc
+
+
+def _mk_message(content=None, tool_calls=None):
+    """Assistant-message stand-in whose model_dump returns plain dicts.
+
+    Mirrors real pydantic: the attribute holds objects, model_dump() serializes
+    tool_calls to dicts — which is what lands in orch.messages.
+    """
+    msg = MagicMock()
+    msg.content = content
+    msg.tool_calls = tool_calls
+
+    def _dump():
+        d: dict = {"role": "assistant", "content": msg.content}
+        if msg.tool_calls:
+            d["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments,
+                    },
+                }
+                for tc in msg.tool_calls
+            ]
+        return d
+
+    msg.model_dump = _dump
+    return msg
+
+
+def _mk_response(message):
+    resp = MagicMock()
+    resp.choices = [MagicMock(message=message)]
+    return resp
+
+
+class _ScriptedProvider:
+    """Returns the queued responses in order, one per chat_completion call."""
+
+    name = "fake"
+
+    def __init__(self, responses: List[Any]):
+        self._responses = list(responses)
+        self.calls = 0
+
+    async def chat_completion(self, **kwargs) -> Any:
+        self.calls += 1
+        return self._responses.pop(0)
+
+    def pop_last_cache_stats(self):
+        return {"read": 0, "create": 0}
+
+    def pop_last_reasoning(self) -> Optional[str]:
+        return None
+
+
+def _build_orch(provider: Optional[_ScriptedProvider] = None) -> AgentOrchestrator:
+    orch = AgentOrchestrator(
+        client=MagicMock(),
+        mcp_manager=MagicMock(),
+        model_name="test-model",
+        tools=[],
+        session_id="sess-abandon",
+        provider_getter=(lambda: provider),
+    )
+    orch.messages = [{"role": "system", "content": "sys"}]
+    orch._l4_pending = False
+    orch.retrieval_enabled = False
+    orch.context_size_check_enabled = False
+    return orch
+
+
+def _unanswered(messages: List[dict]) -> List[str]:
+    """tool_call ids declared by an assistant with no matching role=tool reply."""
+    answered = {
+        m.get("tool_call_id")
+        for m in messages
+        if m.get("role") == "tool"
+    }
+    declared: List[str] = []
+    for m in messages:
+        if m.get("role") == "assistant":
+            declared += [tc["id"] for tc in (m.get("tool_calls") or [])]
+    return [tcid for tcid in declared if tcid not in answered]
+
+
+# ---------- _repair_dangling_tool_calls unit ----------
+
+
+def test_repair_leaves_well_formed_history_untouched():
+    orch = _build_orch()
+    orch.messages += [
+        {"role": "user", "content": "lights on"},
+        {"role": "assistant", "tool_calls": [{"id": "c1"}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        {"role": "assistant", "content": "Done."},
+    ]
+    before = list(orch.messages)
+
+    assert orch._repair_dangling_tool_calls() == 0
+    assert orch.messages == before
+
+
+def test_repair_fills_trailing_gap():
+    orch = _build_orch()
+    orch.messages += [
+        {"role": "user", "content": "lights on"},
+        {"role": "assistant", "tool_calls": [{"id": "c1"}]},
+    ]
+
+    assert orch._repair_dangling_tool_calls() == 1
+    last = orch.messages[-1]
+    assert last["role"] == "tool"
+    assert last["tool_call_id"] == "c1"
+    assert json.loads(last["content"])["error"] == "tool_call_abandoned"
+    assert _unanswered(orch.messages) == []
+
+
+def test_repair_tops_up_partially_answered_call_batch():
+    """Disconnect after the first of two parallel tool calls resolved."""
+    orch = _build_orch()
+    orch.messages += [
+        {"role": "user", "content": "lights and lock"},
+        {"role": "assistant", "tool_calls": [{"id": "c1"}, {"id": "c2"}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+    ]
+
+    assert orch._repair_dangling_tool_calls() == 1
+    assert [m.get("tool_call_id") for m in orch.messages if m["role"] == "tool"] == ["c1", "c2"]
+    assert _unanswered(orch.messages) == []
+
+
+def test_repair_inserts_mid_history_gap_in_place():
+    """Synthetic result goes right after its own assistant, not at the end."""
+    orch = _build_orch()
+    orch.messages += [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "tool_calls": [{"id": "c1"}]},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "hi"},
+    ]
+
+    assert orch._repair_dangling_tool_calls() == 1
+    roles = [(m["role"], m.get("tool_call_id") or m.get("content")) for m in orch.messages]
+    assert roles[2] == ("assistant", None)
+    assert roles[3] == ("tool", "c1")
+    assert roles[4] == ("user", "second")
+
+
+# ---------- run() finally ----------
+
+
+async def test_generator_closed_mid_tool_loop_leaves_history_valid():
+    """The disconnect shape: consumer stops iterating right after TOOL_CALL."""
+    tc = _mk_tool_call("call_abandon_1")
+    provider = _ScriptedProvider([_mk_response(_mk_message(tool_calls=[tc]))])
+    orch = _build_orch(provider)
+
+    stream = orch.run("turn on the kitchen lights")
+    seen: List[EventType] = []
+    async for ev in stream:
+        seen.append(ev.type)
+        if ev.type == EventType.TOOL_CALL:
+            break  # client vanished; nothing drains the rest
+    await stream.aclose()
+
+    assert EventType.TOOL_CALL in seen
+    assert any(
+        m.get("role") == "assistant" and m.get("tool_calls") for m in orch.messages
+    ), "precondition: the assistant tool_calls message was already appended"
+    assert _unanswered(orch.messages) == []
+
+
+async def test_completed_turn_synthesizes_nothing():
+    provider = _ScriptedProvider([_mk_response(_mk_message(content="All set."))])
+    orch = _build_orch(provider)
+
+    events = [ev async for ev in orch.run("hello")]
+
+    assert events[-1].type == EventType.DONE
+    assert not [m for m in orch.messages if m.get("role") == "tool"]
+
+
+async def test_resumed_session_with_inherited_gap_is_healed_before_the_llm_call():
+    """A history flushed mid-turn before this fix must not fail its next turn."""
+    provider = _ScriptedProvider([_mk_response(_mk_message(content="Recovered."))])
+    orch = _build_orch(provider)
+    orch.messages += [
+        {"role": "user", "content": "earlier query"},
+        {"role": "assistant", "tool_calls": [{"id": "poisoned"}]},
+    ]
+
+    sent: List[List[dict]] = []
+    original = provider.chat_completion
+
+    async def _capture(**kwargs):
+        sent.append(list(kwargs["messages"]))
+        return await original(**kwargs)
+
+    provider.chat_completion = _capture
+
+    events = [ev async for ev in orch.run("are you there?")]
+
+    assert events[-1].type == EventType.DONE
+    assert sent, "provider was called"
+    assert _unanswered(sent[0]) == [], "the repair happened before the LLM saw it"
+    assert _unanswered(orch.messages) == []


### PR DESCRIPTION
Closes #39.

## Problem
`orchestrator.run()` appends the assistant message carrying `tool_calls` **before** it yields TOOL_CALL/TOOL_RESULT, and appends the matching `role=tool` replies **after**. Any consumer that stops iterating in that window leaves the pooled session with unanswered `tool_calls` — the exact "invalid message sequence … that the provider rejects" the orchestrator's own comment warns about. Every later turn on that `session_id` then fails, and the broken history gets flushed to `conversation_db`.

Two ways in:
- **`/ws/chat`** — `await websocket.send_json(...)` sits bare inside the `async for` body. A client that drops mid-turn makes it raise (uvicorn 0.50 raises `ClientDisconnected`), abandoning the generator at its yield.
- **`/api/chat`** — uvicorn cancels the handler task on disconnect; if the cancel lands while the consumer is awaiting (e.g. `record_turn`), the generator is left suspended for the GC to finalize whenever.

## Fix
- **WS drains instead of abandoning**: on send failure, log, stop sending, and keep pulling events to completion (METRIC still recorded) so the turn's tool results land; then close the socket with 1006.
- **Deterministic close on both paths**: `contextlib.aclosing(orch.run(...))` so cancellation runs the generator's `finally` immediately rather than at GC time.
- **Belt-and-braces repair** in `run()`'s `finally`: `_repair_dangling_tool_calls()` answers any leftover `tool_calls` with a synthetic `{"error": "tool_call_abandoned"}` result, inserted right after that assistant message's existing tool replies (not blindly at the end). It is `await`-free — a `finally` in an async generator can't suspend while being closed.
- **Self-healing**: the same repair runs at turn start, so sessions poisoned before this fix — or cold-resumed from a mid-turn flush — recover before their next LLM call instead of after.

## Tests
New `services/agent/tests/test_abandoned_turn_repair.py` (7 tests): repair unit cases (well-formed history untouched, trailing gap, partially answered batch, mid-history gap placed in order), the disconnect shape via `aclose()` mid tool-loop, no-op on a completed turn, and inherited-gap healing verified against the messages actually sent to the provider.

Verified they fail without the fix (6/7 red, the no-op case green).

```
386 passed in 7.96s
```
Full agent suite, `--ignore=tests/test_integration_memory_review.py` (that one is open issue #120 — it mutates the production Qdrant collection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)